### PR TITLE
Support the basic authentication on the Redfish API

### DIFF
--- a/src/common/config.py
+++ b/src/common/config.py
@@ -13,6 +13,7 @@ MCP_TRANSPORT = os.getenv('MCP_TRANSPORT', 'stdio')
 
 REDFISH_CFG = {"hosts": os.getenv('REDFISH_HOSTS', '[{"address": "127.0.0.1"}]'),
              "port": int(os.getenv('REDFISH_PORT', 443)),
+             "auth_method": os.getenv('REDFISH_AUTH_METHOD', 'session'),
              "username": os.getenv('REDFISH_USERNAME', ""),
              "password": os.getenv('REDFISH_PASSWORD',''),
              "tls_server_ca_cert": os.getenv('REDFISH_SERVER_CA_CERT', None)}


### PR DESCRIPTION
The user can configure with the REDFISH_AUTH_METHOD environment variable whether "session" or "basic" authentication method should be used on the Redfish API. The user can configure with the "auth_method" host level parameter whether "session" or "basic" authentication should be used on the Redfish API. The host level conifgration has priority over the global REDFISH_AUTH_METHOD parameter.