### PR TITLE
Refactoring the Redfish client

### DIFF
--- a/src/common/client.py
+++ b/src/common/client.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Nokia
+# Licensed under the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import redfish
+from redfish.rest.v1 import AuthMethod
+from fastmcp.exceptions import ToolError, ValidationError
+
+class RedfishClient:
+    def __init__(self, server_cfg, common_cfg):
+        self.server_cfg = server_cfg
+        self.common_cfg = common_cfg
+        self.client = None
+        self._setup_client()
+
+    def _setup_client(self):
+        auth_method = self.server_cfg.get("auth_method") or self.common_cfg.REDFISH_CFG.get("auth_method")
+        if auth_method not in (AuthMethod.BASIC, AuthMethod.SESSION):
+            raise ValidationError(f"Invalid auth_method: {auth_method}. Allowed values: {AuthMethod.BASIC}, {AuthMethod.SESSION}")
+        username = self.server_cfg.get("username") or self.common_cfg.REDFISH_CFG.get("username")
+        password = self.server_cfg.get("password") or self.common_cfg.REDFISH_CFG.get("password")
+        port = self.server_cfg.get("port") or self.common_cfg.REDFISH_CFG.get("port", 443)
+        base_url = f"https://{self.server_cfg.get('address')}:{port}"
+        try:
+            self.client = redfish.redfish_client(base_url=base_url, username=username, password=password, default_prefix="/redfish/v1")
+        except Exception as e:
+            raise ToolError(f"Failed to create Redfish client: {e}")
+        ca_cert = self.server_cfg.get("tls_server_ca_cert") or self.common_cfg.REDFISH_CFG.get("tls_server_ca_cert")
+        if ca_cert:
+            self.client.cafile = ca_cert
+        try:
+            self.client.login(auth=auth_method)
+        except Exception as e:
+            raise ToolError(f"Redfish login failed: {e}")
+
+    def get(self, resource_path):
+        try:
+            response = self.client.get(resource_path)
+        except Exception as e:
+            raise ToolError(f"Redfish GET request failed: {e}")
+        if response.status not in (200, 201):
+            raise ToolError(f"Redfish GET failed: HTTP {response.status}", getattr(response, 'dict', None))
+        return response.dict
+
+    def logout(self):
+        if self.client:
+            try:
+                self.client.logout()
+            except Exception:
+                pass

--- a/src/tools/get.py
+++ b/src/tools/get.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import urllib.parse
+
+from fastmcp.exceptions import ToolError, ValidationError
+
 import common.config
+from common.client import RedfishClient
 from common.server import mcp
-import redfish
-from fastmcp.exceptions import ValidationError, ToolError
-from redfish.rest.v1 import AuthMethod
 
 @mcp.tool()
 async def get_endpoint_data(url: str) -> dict:
@@ -39,43 +40,11 @@ async def get_endpoint_data(url: str) -> dict:
     if not server_cfg:
         raise ValidationError(f"Server {server_address} not found in config")
 
-    # Get connection parameters
-
-    try:
-        auth_method = server_cfg.get("auth_method") or common.config.REDFISH_CFG.get("auth_method")
-        if auth_method not in (AuthMethod.BASIC, AuthMethod.SESSION):
-            raise ValidationError(f"Invalid auth_method: {auth_method}. Allowed values: {AuthMethod.BASIC}, {AuthMethod.SESSION}")
-        username = server_cfg.get("username") or common.config.REDFISH_CFG.get("username")
-        password = server_cfg.get("password") or common.config.REDFISH_CFG.get("password")
-        port = server_cfg.get("port") or common.config.REDFISH_CFG.get("port", 443)
-    except Exception as e:
-        raise ToolError(f"Failed to read server config: {e}")
-
-    base_url = f"https://{server_address}:{port}"
     client = None
     try:
-        try:
-            client = redfish.redfish_client(base_url=base_url, username=username, password=password, default_prefix="/redfish/v1")
-        except Exception as e:
-            raise ToolError(f"Failed to create Redfish client: {e}")
-        # Set CA cert or skip verification as needed
-        ca_cert = server_cfg.get("tls_server_ca_cert") or common.config.REDFISH_CFG.get("tls_server_ca_cert")
-        if ca_cert:
-            client.cafile = ca_cert
-        try:
-            client.login(auth=auth_method)
-        except Exception as e:
-            raise ToolError(f"Redfish login failed: {e}")
-        try:
-            response = client.get(resource_path)
-        except Exception as e:
-            raise ToolError(f"Redfish GET request failed: {e}")
-        if response.status not in (200, 201):
-            raise ToolError(f"Redfish GET failed: HTTP {response.status}", getattr(response, 'dict', None))
-        return response.dict
+        client = RedfishClient(server_cfg, common.config)
+        response_dict = client.get(resource_path)
+        return response_dict
     finally:
         if client:
-            try:
-                client.logout()
-            except Exception:
-                pass
+            client.logout()

--- a/test/tools/test_get.py
+++ b/test/tools/test_get.py
@@ -41,22 +41,17 @@ class TestGetEndpointData(unittest.IsolatedAsyncioTestCase):
                     await client.call_tool("get_endpoint_data", {"url": url})
 
     @patch('common.config.get_hosts')
-    async def test_successful_fetch(self, mock_get_hosts):
+    @patch('tools.get.RedfishClient')
+    async def test_successful_fetch(self, mock_redfish_client, mock_get_hosts):
         mock_get_hosts.return_value = [{'address': 'host1', 'username': 'u', 'password': 'p'}]
         url = 'https://host1/redfish/v1/Systems/1'
-        mock_response = MagicMock()
-        mock_response.status = 200
-        mock_response.dict = {'data': 'ok'}
-        mock_client = MagicMock()
-        mock_client.login.return_value = None
-        mock_client.cafile = None
-        mock_client.get.return_value = mock_response
-        with patch('tools.get.redfish.redfish_client', return_value=mock_client):
-            with patch.object(mock_client, 'get_resource', return_value={'data': 'ok'}):
-                async with Client(common.server.mcp) as client:
-                    result = await client.call_tool("get_endpoint_data", {"url": url})
-                    self.assertEqual(len(result), 1)
-                    self.assertEqual(json.loads(result[0].text), {'data': 'ok'})
+        mock_instance = MagicMock()
+        mock_instance.get.return_value = {'data': 'ok'}
+        mock_redfish_client.return_value = mock_instance
+        async with Client(common.server.mcp) as client:
+            result = await client.call_tool("get_endpoint_data", {"url": url})
+            self.assertEqual(len(result), 1)
+            self.assertEqual(json.loads(result[0].text), {'data': 'ok'})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We move the client implementation into a shared location so all tools can use the same client implementation.