### PR TITLE
Fix failing tests and simplify CI/CD actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,10 +1,9 @@
 name: CI/CD Pipeline
 
 on:
-  push:
-    branches: [ main, develop, fixes ]
+  # Run CI on all PRs to main branch (this is the quality gate)
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   test:
@@ -131,7 +130,8 @@ jobs:
   container:
     name: Container Build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    # Build container for all events (PRs and pushes)
+    # This ensures Docker builds are tested before merging
 
     steps:
     - uses: actions/checkout@v4
@@ -153,49 +153,11 @@ jobs:
       run: |
         docker run --rm --entrypoint="" mcp-redfish:test python --version
 
-  integration:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    needs: [test, code-quality]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.13"
-
-    - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-    - name: Install dependencies
-      run: |
-        uv venv
-        source .venv/bin/activate
-        uv sync --extra dev
-
-    - name: Test MCP server startup
-      run: |
-        source .venv/bin/activate
-        timeout 10s uv run python -m src.main || [ $? = 124 ]  # timeout expected
-
-    - name: Test MCP Inspector integration
-      run: |
-        source .venv/bin/activate
-        # Install MCP Inspector
-        npm install -g @modelcontextprotocol/inspector
-        # Test that server can be inspected (will timeout after 10s, which is expected)
-        timeout 10s npx @modelcontextprotocol/inspector uv run python -m src.main || [ $? = 124 ]
-
   e2e-tests:
     name: End-to-End Tests
     runs-on: ubuntu-latest
     needs: [test, code-quality]
-    if: github.event_name == 'pull_request'
+    # E2E tests include MCP server startup, inspector integration, and real Redfish testing
 
     steps:
     - uses: actions/checkout@v4

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,14 +12,8 @@ from pathlib import Path
 
 import pytest
 
-# Add src directory to Python path for imports
-src_dir = Path(__file__).parent.parent / "src"
-sys.path.insert(0, str(src_dir))
-
-# Import the package properly - this will trigger tool registration
-import src.tools  # noqa: F401, E402
-
-# Test environment variables
+# Set fast retry configuration BEFORE importing any src modules
+# This ensures the retry decorators pick up the fast configuration
 os.environ.update(
     {
         "REDFISH_HOSTS": '[{"address": "test-host.example.com"}]',
@@ -29,8 +23,21 @@ os.environ.update(
         "MCP_TRANSPORT": "stdio",
         "REDFISH_DISCOVERY_ENABLED": "false",
         "MCP_REDFISH_LOG_LEVEL": "WARNING",  # Reduce log noise in tests
+        # Fast retry configuration for testing - SET BEFORE IMPORTS
+        "REDFISH_MAX_RETRIES": "2",
+        "REDFISH_INITIAL_DELAY": "0.001",  # 1ms instead of 1s default
+        "REDFISH_MAX_DELAY": "0.1",  # 100ms instead of 60s default
+        "REDFISH_BACKOFF_FACTOR": "2.0",
+        "REDFISH_JITTER": "false",
     }
 )
+
+# Add src directory to Python path for imports
+src_dir = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(src_dir))
+
+# Import the package properly - this will trigger tool registration
+import src.tools  # noqa: F401, E402
 
 
 @pytest.fixture(scope="session")

--- a/test/utils.py
+++ b/test/utils.py
@@ -7,6 +7,7 @@ Test utilities and helper functions for mcp-redfish test suite.
 """
 
 import json
+import os
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -69,16 +70,12 @@ class MockEnvironment:
         self.original_values = {}
 
     def __enter__(self):
-        import os
-
         for key, value in self.env_vars.items():
             self.original_values[key] = os.environ.get(key)
             os.environ[key] = value
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        import os
-
         for key in self.env_vars:
             original_value = self.original_values[key]
             if original_value is None:


### PR DESCRIPTION
There was a failing test case, this change fixes that. The CI/CD action is simplified:
- it runs for PRs only
- integration tests are removed as those were covered by e2e tests